### PR TITLE
feat(eks): add nodePoolsLaunch kind to cluster.yml

### DIFF
--- a/fury-on-eks/README.md
+++ b/fury-on-eks/README.md
@@ -299,6 +299,7 @@ spec:
   dmzCIDRRange:
   - 10.0.0.0/16
   sshPublicKey: example-ssh-key # put your id_rsa.pub file content here
+  nodePoolsLaunchKind: "launch_templates"
   nodePools:
   - name: fury
     version: null

--- a/fury-on-eks/infrastructure/cluster.yml
+++ b/fury-on-eks/infrastructure/cluster.yml
@@ -11,6 +11,7 @@ spec:
   dmzCIDRRange:
   - 10.0.0.0/16
   sshPublicKey: example-ssh-key
+  nodePoolsLaunchKind: "launch_templates"
   nodePools:
   - name: fury
     version: null


### PR DESCRIPTION
we've updated the docker image to use Furyctl v0.9.0, so now we need to set explicitly the nodePoolsLaunchKind configuation in the cluster.yml file.