### PR TITLE
feat(eks): update guide to Kubernetes 1.25 and KFD 1.25.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
-![Fury Logo](./utils/images/fury_logo.png)
 # Getting Started with Kubernetes Fury Distribution
+
+![Fury Logo](./utils/images/fury_logo.png)
 
 Getting started guides to create Fury clusters and deploy the Kubernetes Fury Distribution in different environments
 
-|                     Guide                      |  Environment   | Fury Release  | Kubernetes Version |  Status            |
-|:----------------------------------------------:|:--------------:|:-------------:|:------------------:|:------------------:|
-| [Fury on EKS](fury-on-eks/README.md)           |   ☁ AWS        |   v1.24.0     |       v1.24        | :white_check_mark: |
-| [Fury on GKE](fury-on-gke/README.md)           |   ☁ GCP        |   v1.6.0      |       v1.18        | :white_check_mark: |
-| [Fury on OVHcloud](fury-on-ovhcloud/README.md) |   ☁ OVHcloud   |   v1.24.0     |       v1.24        | :white_check_mark: |
-| [Fury on Minikube](fury-on-minikube/README.md) | 💻 On premises |   v1.23.1     |       v1.23.1      | :white_check_mark: |
-| [Fury on Talos](fury-on-talos/README.md)       | 💻 On premises |   v1.23.1     |       v1.23.6      | :white_check_mark: |
+|                     Guide                      |  Environment  | Fury Release | Kubernetes Version |       Status       |
+| :--------------------------------------------: | :-----------: | :----------: | :----------------: | :----------------: |
+|      [Fury on EKS](fury-on-eks/README.md)      |     ☁ AWS     |   v1.25.1    |       v1.25        | :white_check_mark: |
+|      [Fury on GKE](fury-on-gke/README.md)      |     ☁ GCP     |    v1.6.0    |       v1.18        | :white_check_mark: |
+| [Fury on OVHcloud](fury-on-ovhcloud/README.md) |  ☁ OVHcloud   |   v1.24.0    |       v1.24        | :white_check_mark: |
+| [Fury on Minikube](fury-on-minikube/README.md) | 💻 On premises |   v1.23.1    |      v1.23.1       | :white_check_mark: |
+|    [Fury on Talos](fury-on-talos/README.md)    | 💻 On premises |   v1.23.1    |      v1.23.6       | :white_check_mark: |
 
 - :white_check_mark: Currently available
 - :hammer: In progress

--- a/fury-on-eks/Furyfile.yml
+++ b/fury-on-eks/Furyfile.yml
@@ -1,11 +1,12 @@
 versions:
-  networking: v1.10.0
-  monitoring: v2.0.1
-  logging: v3.0.1
-  ingress: v1.13.1
-  dr: v1.10.1
-  auth: v0.0.2
-  aws: v2.0.0
+  networking: v1.12.2
+  monitoring: v2.1.0
+  logging: v3.1.3
+  ingress: v1.14.1
+  dr: v1.11.0
+  auth: v0.0.3
+  aws: v2.2.0
+  opa: v1.8.0
 
 bases:
   - name: networking

--- a/fury-on-eks/infrastructure/bootstrap.yml
+++ b/fury-on-eks/infrastructure/bootstrap.yml
@@ -4,13 +4,13 @@ metadata:
 spec:
   networkCIDR: 10.0.0.0/16
   publicSubnetsCIDRs:
-  - 10.0.1.0/24
-  - 10.0.2.0/24
-  - 10.0.3.0/24
+    - 10.0.1.0/24
+    - 10.0.2.0/24
+    - 10.0.3.0/24
   privateSubnetsCIDRs:
-  - 10.0.101.0/24
-  - 10.0.102.0/24
-  - 10.0.103.0/24
+    - 10.0.101.0/24
+    - 10.0.102.0/24
+    - 10.0.103.0/24
   vpn:
     instances: 1
     port: 1194
@@ -20,7 +20,7 @@ spec:
     dhParamsBits: 2048
     subnetCIDR: 172.16.0.0/16
     sshUsers:
-    - <GITHUB_USER>
+      - <GITHUB_USER>
 executor:
   # state:
   #   backend: s3

--- a/fury-on-eks/infrastructure/cluster.yml
+++ b/fury-on-eks/infrastructure/cluster.yml
@@ -2,23 +2,23 @@ kind: Cluster
 metadata:
   name: fury-eks-demo
 spec:
-  version: 1.24
+  version: 1.25
   network: <VPC_ID>
   subnetworks:
-  - <PRIVATE_SUBNET1_ID>
-  - <PRIVATE_SUBNET2_ID>
-  - <PRIVATE_SUBNET3_ID>
+    - <PRIVATE_SUBNET1_ID>
+    - <PRIVATE_SUBNET2_ID>
+    - <PRIVATE_SUBNET3_ID>
   dmzCIDRRange:
-  - 10.0.0.0/16
-  sshPublicKey: example-ssh-key
+    - 10.0.0.0/16
+  sshPublicKey: example-ssh-key # ⚠️ change me
   nodePoolsLaunchKind: "launch_templates"
   nodePools:
-  - name: fury
-    version: null
-    minSize: 3
-    maxSize: 3 
-    instanceType: t3.large
-    volumeSize: 50
+    - name: fury
+      version: null
+      minSize: 3
+      maxSize: 3
+      instanceType: t3.large
+      volumeSize: 50
 executor:
   # state:
   #   backend: s3

--- a/fury-on-eks/manifests/logging/kustomization.yaml
+++ b/fury-on-eks/manifests/logging/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ../../vendor/katalog/logging/configs
   - ../../vendor/katalog/logging/opensearch-single
   - ../../vendor/katalog/logging/opensearch-dashboards
+  - ../../vendor/katalog/logging/minio-ha
 
   - resources/ingress.yml
 

--- a/fury-on-eks/manifests/opa/kustomization.yaml
+++ b/fury-on-eks/manifests/opa/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 
 resources:
   - ../../vendor/katalog/opa/gatekeeper
+  - resources/ingress.yml

--- a/fury-on-eks/manifests/opa/resources/ingress.yml
+++ b/fury-on-eks/manifests/opa/resources/ingress.yml
@@ -1,0 +1,23 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    forecastle.stakater.com/expose: "true"
+    forecastle.stakater.com/appName: "Gatekeeper Policy Manager"
+    forecastle.stakater.com/icon: "https://raw.githubusercontent.com/sighupio/gatekeeper-policy-manager/master/app/static-content/logo.svg"
+  name: gpm
+  namespace: gatekeeper-system
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: gpm.fury.info
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: gatekeeper-policy-manager
+                port:
+                  name: http

--- a/fury-on-eks/terraform/main.tf
+++ b/fury-on-eks/terraform/main.tf
@@ -1,13 +1,13 @@
 terraform {
-#   backend "s3" {
-#     bucket: <S3_BUCKET>
-#     key: <MY_KEY> 
-#     region: <S3_BUCKET_REGION>
-#   }
-  required_version = ">= 0.12"
+  # backend "s3" {
+  #   bucket = "fury-demo-eks"
+  #   key    = "fury/distribution"
+  #   region = "eu-west-1"
+  # }
+  required_version = ">= 0.15.4"
 
   required_providers {
-    aws        = "=3.37.0"
+    aws = "=3.37.0"
   }
 }
 
@@ -36,6 +36,6 @@ module "velero" {
 }
 
 module "ebs_csi_driver_iam_role" {
-  source             = "../vendor/modules/aws/iam-for-ebs-csi-driver"
-  cluster_name       = var.cluster_name
+  source       = "../vendor/modules/aws/iam-for-ebs-csi-driver"
+  cluster_name = var.cluster_name
 }


### PR DESCRIPTION
Update Fury on EKS quick start guide to Kubernetes 1.25 and KFD 1.25.0.

Notice that:

- I used networking v1.12.2 instead of 1.12.1 to avoid the missing end slash in the registry URL issue
- This PR uses images that will be added to the repository in #34
- Added missing instructions to test the OPA module
- Improved the OpenDashboard instructions

Closes #27 