### PR TITLE
feat(ovh): update guide to KFD 1.25.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
-![Fury Logo](./utils/images/fury_logo.png)
 # Getting Started with Kubernetes Fury Distribution
+
+![Fury Logo](./utils/images/fury_logo.png)
 
 Getting started guides to create Fury clusters and deploy the Kubernetes Fury Distribution in different environments
 
-|                     Guide                      |  Environment   | Fury Release  | Kubernetes Version |  Status            |
-|:----------------------------------------------:|:--------------:|:-------------:|:------------------:|:------------------:|
-| [Fury on EKS](fury-on-eks/README.md)           |   ☁ AWS        |   v1.24.0     |       v1.24        | :white_check_mark: |
-| [Fury on GKE](fury-on-gke/README.md)           |   ☁ GCP        |   v1.6.0      |       v1.18        | :white_check_mark: |
-| [Fury on OVHcloud](fury-on-ovhcloud/README.md) |   ☁ OVHcloud   |   v1.24.0     |       v1.24        | :white_check_mark: |
-| [Fury on Minikube](fury-on-minikube/README.md) | 💻 On premises |   v1.23.1     |       v1.23.1      | :white_check_mark: |
-| [Fury on Talos](fury-on-talos/README.md)       | 💻 On premises |   v1.23.1     |       v1.23.6      | :white_check_mark: |
+|                     Guide                      |  Environment  | Fury Release | Kubernetes Version |       Status       |
+| :--------------------------------------------: | :-----------: | :----------: | :----------------: | :----------------: |
+|      [Fury on EKS](fury-on-eks/README.md)      |     ☁ AWS     |   v1.24.0    |       v1.24        | :white_check_mark: |
+|      [Fury on GKE](fury-on-gke/README.md)      |     ☁ GCP     |    v1.6.0    |       v1.18        | :white_check_mark: |
+| [Fury on OVHcloud](fury-on-ovhcloud/README.md) |  ☁ OVHcloud   |   v1.25.1    |       v1.25        | :white_check_mark: |
+| [Fury on Minikube](fury-on-minikube/README.md) | 💻 On premises |   v1.23.1    |      v1.23.1       | :white_check_mark: |
+|    [Fury on Talos](fury-on-talos/README.md)    | 💻 On premises |   v1.23.1    |      v1.23.6       | :white_check_mark: |
 
 - :white_check_mark: Currently available
 - :hammer: In progress

--- a/fury-on-ovhcloud/Furyfile.yml
+++ b/fury-on-ovhcloud/Furyfile.yml
@@ -1,7 +1,7 @@
 versions:
-  monitoring: v2.0.1
-  logging: v3.0.1
-  ingress: v1.13.1
+  monitoring: v2.1.0
+  logging: v3.1.3
+  ingress: v1.14.1
 
 bases:
   - name: monitoring

--- a/fury-on-ovhcloud/infrastructure/terraform/modules/kubernetes/k8s_pvnw/variables.tfvars
+++ b/fury-on-ovhcloud/infrastructure/terraform/modules/kubernetes/k8s_pvnw/variables.tfvars
@@ -6,7 +6,7 @@ region = "GRA7"
 
 kube = {
   name            = "mykubernetesCluster"
-  version         = "1.24"
+  version         = "1.25"
   pv_network_name = "myNetwork"
   gateway_ip      = "192.168.20.1"
 }

--- a/fury-on-ovhcloud/infrastructure/terraform/variables.tfvars
+++ b/fury-on-ovhcloud/infrastructure/terraform/variables.tfvars
@@ -28,7 +28,7 @@ router = {
 kube = {
   name            = "furykubernetesCluster"
   pv_network_name = "furyNetwork"
-  version         = "1.24"
+  version         = "1.25"
   gateway_ip      = "10.0.0.1"
 }
 

--- a/fury-on-ovhcloud/manifests/logging/kustomization.yaml
+++ b/fury-on-ovhcloud/manifests/logging/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ../../vendor/katalog/logging/configs
   - ../../vendor/katalog/logging/opensearch-single
   - ../../vendor/katalog/logging/opensearch-dashboards
+  - ../../vendor/katalog/logging/minio-ha
 
   - resources/ingress.yml
 


### PR DESCRIPTION
Update getting started guide to use KFD 1.25.1 and Kubernetes 1.25.

Please notice that this PR uses images that will be added when the PR #34 is merged.