### PR TITLE
feat(fury-on-vms): use furyctl for pki and kfd 1.29.3

### DIFF
--- a/fury-on-vms/furyagent.yml
+++ b/fury-on-vms/furyagent.yml
@@ -1,7 +1,0 @@
-# Copyright (c) 2021 SIGHUP s.r.l All rights reserved.
-# Use of this source code is governed by a BSD-style
-# license that can be found in the LICENSE file.
-
-storage:
-  provider: local
-  path: .

--- a/fury-on-vms/furyctl.yaml
+++ b/fury-on-vms/furyctl.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/v1.29.3/schemas/public/onpremises-kfd-v1alpha2.json
 
 ---
 apiVersion: kfd.sighup.io/v1alpha2
@@ -8,7 +9,7 @@ kind: OnPremises
 metadata:
   name: getting-started
 spec:
-  distributionVersion: v1.29.0
+  distributionVersion: v1.29.3
   kubernetes:
     pkiFolder: ./pki
     ssh:


### PR DESCRIPTION
- Use furyctl for creating the PKI instead of furyagent.
- Bump KFD version to v1.29.3
- Fix some typos and formatting.