### PR TITLE
fix: lint all markdown files

### DIFF
--- a/fury-on-eks/README.md
+++ b/fury-on-eks/README.md
@@ -29,28 +29,28 @@ To follow this tutorial, you need:
 
 2. Clone the [fury getting started repository][fury-getting-started-repository] containing the example code used in this tutorial:
 
-```bash
-mkdir -p /tmp/fury-getting-started && git -C /tmp/fury-getting-started clone https://github.com/sighupio/fury-getting-started/ .
-cd /tmp/fury-getting-started/fury-on-eks
-```
+    ```bash
+    mkdir -p /tmp/fury-getting-started && git -C /tmp/fury-getting-started clone https://github.com/sighupio/fury-getting-started/ .
+    cd /tmp/fury-getting-started/fury-on-eks
+    ```
 
 3. Install `furyctl` binary: https://github.com/sighupio/furyctl#installation
 
 4. Setup your AWS credentials by exporting the following environment variables:
 
-```bash
-export AWS_PROFILE=<YOUR_AWS_PROFILE_NAME>
-```
+    ```bash
+    export AWS_PROFILE=<YOUR_AWS_PROFILE_NAME>
+    ```
 
-If you don't have an AWS profile configured, you can create one by running the following command:
+    If you don't have an AWS profile configured, you can create one by running the following command:
 
-```bash
-$ aws configure --profile <YOUR_AWS_PROFILE_NAME>
-AWS Access Key ID [None]: <YOUR_AWS_ACCESS_KEY_ID>
-AWS Secret Access Key [None]: <YOUR_AWS_SECRET_ACCESS_KEY>
-Default region name [None]: <YOUR_AWS_REGION>
-Default output format [None]: json
-```
+    ```bash
+    $ aws configure --profile <YOUR_AWS_PROFILE_NAME>
+    AWS Access Key ID [None]: <YOUR_AWS_ACCESS_KEY_ID>
+    AWS Secret Access Key [None]: <YOUR_AWS_SECRET_ACCESS_KEY>
+    Default region name [None]: <YOUR_AWS_REGION>
+    Default output format [None]: json
+    ```
 
 You are all set ✌️.
 
@@ -65,9 +65,11 @@ The configuration of the Fury cluster is governed by the `furyctl.yaml` file, wh
 is located at `/tmp/fury-getting-started/fury-on-eks/furyctl.yaml`.
 
 > ℹ️ You can also create a sample configuration file by running the following command:
+>
 > ```bash
 > furyctl create config --version v1.29.3 -c custom-furyctl.yaml
 > ```
+>
 > and edit the `custom-furyctl.yaml` file to fit your needs, when you are done you can use the `--config` flag to specify the path to the configuration file in the
 > following commands.
 > In this demo we will stick to the `furyctl.yaml` file.
@@ -245,7 +247,7 @@ The Distribution section of the `furyctl.yaml` file contains the following param
             bucketName: <S3_VELERO_BUCKET_NAME>
       policy:
         type: gatekeeper
-        gatekeeper: 
+        gatekeeper:
           enforcementAction: warn
           installDefaultPolicies: true
       auth:
@@ -276,41 +278,43 @@ In this section, you will utilize furyctl to automatically provision an EKS Clus
 
 1. Start by running the furyctl command to create the cluster:
 
-```bash
-furyctl create cluster --outdir $PWD
-```
-> ⏱ The process will take several minutes to complete, you can follow the progress in detail by running the following command on the latest furyctl log file:
->
-> ```bash
-> tail -f .furyctl/furyctl.<timestamp>-<random-id>.log | jq
-> ```
-> `--outdir` flag is used to define in which directory to create the hidden `.furyctl` folder that contains all the required files to install the cluster.
-> If not provided, a `.furyctl` folder will be created in the user home.
+    ```bash
+    furyctl create cluster --outdir $PWD
+    ```
 
-The output should be similar to the following:
+    > ⏱ The process will take several minutes to complete, you can follow the progress in detail by running the following command on the latest furyctl log file:
+    >
+    > ```bash
+    > tail -f .furyctl/furyctl.<timestamp>-<random-id>.log | jq
+    > ```
+    >
+    > `--outdir` flag is used to define in which directory to create the hidden `.furyctl` folder that contains all the required files to install the cluster.
+    > If not provided, a `.furyctl` folder will be created in the user home.
 
-```bash
-INFO Downloading distribution...
-INFO Validating configuration file...
-INFO Downloading dependencies...
-INFO Validating dependencies...
-INFO Creating cluster...
-INFO Creating infrastructure...
-WARN Creating cloud resources, this could take a while...
-INFO Creating Kubernetes Fury cluster...
-WARN Creating cloud resources, this could take a while...
-INFO Saving furyctl configuration file in the cluster...
-INFO Saving distribution configuration file in the cluster...
-INFO Installing Kubernetes Fury Distribution...
-WARN Creating cloud resources, this could take a while...
-INFO Checking that the cluster is reachable...
-INFO Applying manifests...
-INFO Saving furyctl configuration file in the cluster...
-INFO Saving distribution configuration file in the cluster...
-INFO Kubernetes Fury cluster created successfully
-INFO Please remember to kill the VPN connection when you finish doing operations on the cluster
-INFO To connect to the cluster, set the path to your kubeconfig with 'export KUBECONFIG=/private/tmp/fury-getting-started/fury-on-eks/kubeconfig' or use the '--kubeconfig /private/tmp/fury-getting-started/fury-on-eks/kubeconfig' flag in following executions
-```
+    The output should be similar to the following:
+
+    ```bash
+    INFO Downloading distribution...
+    INFO Validating configuration file...
+    INFO Downloading dependencies...
+    INFO Validating dependencies...
+    INFO Creating cluster...
+    INFO Creating infrastructure...
+    WARN Creating cloud resources, this could take a while...
+    INFO Creating Kubernetes Fury cluster...
+    WARN Creating cloud resources, this could take a while...
+    INFO Saving furyctl configuration file in the cluster...
+    INFO Saving distribution configuration file in the cluster...
+    INFO Installing Kubernetes Fury Distribution...
+    WARN Creating cloud resources, this could take a while...
+    INFO Checking that the cluster is reachable...
+    INFO Applying manifests...
+    INFO Saving furyctl configuration file in the cluster...
+    INFO Saving distribution configuration file in the cluster...
+    INFO Kubernetes Fury cluster created successfully
+    INFO Please remember to kill the VPN connection when you finish doing operations on the cluster
+    INFO To connect to the cluster, set the path to your kubeconfig with 'export KUBECONFIG=/private/tmp/fury-getting-started/fury-on-eks/kubeconfig' or use the '--kubeconfig /private/tmp/fury-getting-started/fury-on-eks/kubeconfig' flag in following executions
+    ```
 
 🚀 Success! The distribution is fully deployed. Proceed to the next section to explore the various features it has to offer.
 
@@ -415,7 +419,6 @@ Navigate to https://directory.internal.demo.example.dev to see all the other ing
 
 Navigate to https://grafana.internal.demo.example.dev or click the Grafana icon from Forecastle.
 
-
 #### Discover the logs
 
 Navigate to grafana, and:
@@ -446,15 +449,15 @@ This is what you should see:
 
 1. Create a backup with the `velero` command-line utility:
 
-```bash
-velero backup create --from-schedule manifests test -n kube-system
-```
+    ```bash
+    velero backup create --from-schedule manifests test -n kube-system
+    ```
 
 2. Check the backup status:
 
-```bash
-velero backup get -n kube-system
-```
+    ```bash
+    velero backup get -n kube-system
+    ```
 
 ### (optional) Enforce a Policy with OPA Gatekeeper
 
@@ -472,7 +475,7 @@ Gatekeeper runs as a Validating Admission Webhook, meaning that all the requests
 
 If you list the pods in the `default` namespace, the list it should be empty, confirming that the pod creation was actually rejected:
 
-```console
+```bash
 $ kubectl get pods -n default
 No resources found in default namespace.
 ```
@@ -485,7 +488,7 @@ kubectl run --image busybox bad-pod -n kube-system
 
 Output should be:
 
-```console
+```bash
 pod/bad-pod created
 ```
 
@@ -497,20 +500,20 @@ Clean up the demo environment:
 
 1. Delete the EKS cluster and all the related aws resources:
 
-```bash
-furyctl delete cluster --outdir $PWD
-```
+    ```bash
+    furyctl delete cluster --outdir $PWD
+    ```
 
 2. Write 'yes' and hit <kbd>⏎ Enter</kbd>, when prompted to confirm the deletion.
 
 3. (Optional) Destroy the S3 bucket holding the Terraform state
 
-```bash
-aws s3api delete-objects --bucket $S3_BUCKET \
-  --delete "$(aws s3api list-object-versions --bucket $S3_BUCKET --query='{Objects: Versions[].{Key:Key,VersionId:VersionId}}')"
+    ```bash
+    aws s3api delete-objects --bucket $S3_BUCKET \
+      --delete "$(aws s3api list-object-versions --bucket $S3_BUCKET --query='{Objects: Versions[].{Key:Key,VersionId:VersionId}}')"
 
-aws s3api delete-bucket --bucket $S3_BUCKET
-```
+    aws s3api delete-bucket --bucket $S3_BUCKET
+    ```
 
 ## Conclusions
 
@@ -539,19 +542,6 @@ More about Fury:
 
 [fury-on-minikube]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-minikube
 [fury-on-vms]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-vms
-[fury-on-gke]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-gke
-[fury-on-ovhcloud]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-ovhcloud
-
-[furyagent-repository]: https://github.com/sighupio/furyagent
-
-[provisioner-infrastructure-aws-reference-vpc]: https://github.com/sighupio/fury-eks-installer/tree/main/modules/vpc
-[provisioner-infrastructure-aws-reference-vpn]: https://github.com/sighupio/fury-eks-installer/tree/main/modules/vpn
-[provisioner-kubernetes-aws-reference]: https://github.com/sighupio/fury-eks-installer/tree/main/modules/eks
-
-[tunnelblick]: https://tunnelblick.net/downloads.html
-[openvpn-connect]: https://openvpn.net/vpn-client/
-[openvpn-client]: https://openvpn.net/community-downloads/
-[github-ssh-key-setup]: https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account
 
 [fury-docs]: https://docs.kubernetesfury.com
 [opa-module-docs]: https://docs.kubernetesfury.com/docs/modules/opa/overview
@@ -564,8 +554,4 @@ More about Fury:
 <!-- `media` here is a branch. We used to store all images in that branch and reference them from other branches -->
 [grafana-screenshot]: https://github.com/sighupio/fury-getting-started/blob/media/grafana.png?raw=true
 [grafana-screenshot-logs]: https://github.com/sighupio/fury-getting-started/blob/media/grafana-logs.png?raw=true
-[opensearch-dashboards-screenshot]: https://github.com/sighupio/fury-getting-started/blob/main/utils/images/opensearch_dashboards.png?raw=true
-[opensearch-dashboards-welcome]: https://github.com/sighupio/fury-getting-started/blob/main/utils/images/opensearch-dashboards_welcome.png?raw=true
-[opensearch-dashboards-discover]: https://github.com/sighupio/fury-getting-started/blob/main/utils/images/opensearch-dashboards_discover.png?raw=true
-[opensearch-dashboards-index]: https://github.com/sighupio/fury-getting-started/blob/main/utils/images/opensearch-dashboards_index.png?raw=true
 [forecastle-eks-screenshot]: https://github.com/sighupio/fury-getting-started/blob/media/forecastle_eks.png?raw=true

--- a/fury-on-minikube/README.md
+++ b/fury-on-minikube/README.md
@@ -10,7 +10,7 @@ This tutorial covers the following steps:
 4. Explore some features of the distribution.
 5. Teardown the environment.
 
-> ☁️ If you prefer trying Fury in a cloud environment, check out the [Fury on EKS](../fury-on-eks) tutorial.
+> ☁️ If you prefer trying Fury in a cloud environment, check out the [Fury on EKS][fury-on-eks] tutorial.
 
 The goal of this tutorial is to introduce you to the main concepts of KFD and how to work with its tooling.
 
@@ -38,26 +38,26 @@ cd fury-getting-started/fury-on-minikube
 
 1. Start minikube cluster:
 
-```bash
-export REPO_DIR=$PWD
-export KUBECONFIG=$REPO_DIR/kubeconfig
-minikube start --vm-driver=virtualbox --kubernetes-version v1.29.3 --memory=16384m --cpus=6
-```
+    ```bash
+    export REPO_DIR=$PWD
+    export KUBECONFIG=$REPO_DIR/kubeconfig
+    minikube start --vm-driver=virtualbox --kubernetes-version v1.29.3 --memory=16384m --cpus=6
+    ```
 
-> ⚠️ This command will spin up by default a single-node Kubernetes v1.29.3 cluster, using VirtualBox driver, with 6 CPUs, 16GB RAM and 20 GB Disk.
+    > ⚠️ This command will spin up by default a single-node Kubernetes v1.29.3 cluster, using VirtualBox driver, with 6 CPUs, 16GB RAM and 20 GB Disk.
 
 2. Test the connection to the minikube cluster:
 
-```bash
-kubectl get nodes
-```
+    ```bash
+    kubectl get nodes
+    ```
 
-Output:
+    Output:
 
-```bash
-NAME       STATUS   ROLES           AGE   VERSION
-minikube   Ready    control-plane   9s    v1.29.3
-```
+    ```bash
+    NAME       STATUS   ROLES           AGE   VERSION
+    minikube   Ready    control-plane   9s    v1.29.3
+    ```
 
 ## Step 3 - Install furyctl
 
@@ -145,11 +145,13 @@ Execute the installation with furyctl:
 ```bash
 furyctl apply --outdir $PWD
 ```
+
 > ⏱ The process will take some minutes to complete, you can follow the progress in detail by running the following command:
 >
 > ```bash
 > tail -f .furyctl/furyctl.<timestamp>-<random-id>.log | jq
 > ```
+>
 > `--outdir` flag is used to define in which directory to create the hidden `.furyctl` folder that contains all the required files to install the cluster.
 > If not provided, a `.furyctl` folder will be created in the user home.
 
@@ -157,23 +159,23 @@ The output should be similar to the following:
 
 ```bash
 INFO Downloading distribution...
-INFO Validating configuration file...             
-INFO Downloading dependencies...                  
-INFO Validating dependencies...                   
-INFO Running preflight checks                     
-INFO Checking that the cluster is reachable...    
-INFO Cannot find state in cluster, skipping...    
-INFO Running preupgrade phase...                  
-INFO Preupgrade phase completed successfully      
-INFO Installing Kubernetes Fury Distribution...   
-INFO Checking that the cluster is reachable...    
-INFO Checking storage classes...                  
-INFO Checking if all nodes are ready...           
-INFO Applying manifests...                        
-INFO Kubernetes Fury Distribution installed successfully 
-INFO Applying plugins...                          
-INFO Skipping plugins phase as spec.plugins is not defined 
-INFO Saving furyctl configuration file in the cluster... 
+INFO Validating configuration file...
+INFO Downloading dependencies...
+INFO Validating dependencies...
+INFO Running preflight checks
+INFO Checking that the cluster is reachable...
+INFO Cannot find state in cluster, skipping...
+INFO Running preupgrade phase...
+INFO Preupgrade phase completed successfully
+INFO Installing Kubernetes Fury Distribution...
+INFO Checking that the cluster is reachable...
+INFO Checking storage classes...
+INFO Checking if all nodes are ready...
+INFO Applying manifests...
+INFO Kubernetes Fury Distribution installed successfully
+INFO Applying plugins...
+INFO Skipping plugins phase as spec.plugins is not defined
+INFO Saving furyctl configuration file in the cluster...
 INFO Saving distribution configuration file in the cluster...
 ```
 
@@ -195,17 +197,16 @@ To access the ingresses more easily via the browser, configure your local DNS to
 
 1. Get the address of the cluster IP:
 
-```bash
-minikube ip
-<SOME_IP>
-```
+    ```bash
+    minikube ip
+    <SOME_IP>
+    ```
 
-3. Add the following line to your local `/etc/hosts`:
+2. Add the following line to your local `/etc/hosts`:
 
-```bash
-<SOME_IP> directory.internal.demo.example.dev grafana.internal.demo.example.dev prometheus.internal.demo.example.dev
-
-```
+    ```bash
+    <SOME_IP> directory.internal.demo.example.dev grafana.internal.demo.example.dev prometheus.internal.demo.example.dev
+    ```
 
 Now, you can reach the ingresses directly from your browser.
 
@@ -222,7 +223,6 @@ Navigate to https://directory.fury.info:31443 to see all the other ingresses dep
 [Grafana](https://github.com/grafana/grafana) is an open-source platform for monitoring and observability. Grafana allows you to query, visualize, alert, and understand your metrics.
 
 Navigate to https://grafana.internal.demo.example.dev:31443 or click the Grafana icon from Forecastle (remember to append the port 31443 to the url).
-
 
 #### Discover the logs
 
@@ -254,9 +254,9 @@ Take a look around and test the other dashboards available.
 
 1. Delete the minikube cluster:
 
-```bash
-minikube delete
-```
+    ```bash
+    minikube delete
+    ```
 
 ## Conclusions
 
@@ -280,27 +280,10 @@ More about Fury:
 - [Fury Documentation][fury-docs]
 
 <!-- Links -->
-[fury-getting-started-repository]: https://github.com/sighupio/fury-getting-started/
-[fury-getting-started-dockerfile]: https://github.com/sighupio/fury-getting-started/blob/main/utils/docker/Dockerfile
-
-[fury-on-minikube]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-minikube
 [fury-on-eks]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-eks
-[fury-on-gke]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-gke
-[fury-on-ovhcloud]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-ovhcloud
 [fury-on-vms]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-vms
 
-[furyagent-repository]: https://github.com/sighupio/furyagent
-
-[provisioner-bootstrap-aws-reference]: https://docs.kubernetesfury.com/docs/cli-reference/furyctl/provisioners/aws-bootstrap/
-
-[tunnelblick]: https://tunnelblick.net/downloads.html
-[openvpn-connect]: https://openvpn.net/vpn-client/
-[github-ssh-key-setup]: https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account
-
 [fury-docs]: https://docs.kubernetesfury.com
-[fury-docs-modules]: https://docs.kubernetesfury.com/docs/overview/modules/
-
-[furyctl-docs]: https://docs.kubernetesfury.com/docs/infrastructure/furyctl
 
 <!-- Images -->
 [grafana-screenshot]: https://github.com/sighupio/fury-getting-started/blob/media/grafana.png?raw=true

--- a/fury-on-vms/README.md
+++ b/fury-on-vms/README.md
@@ -2,7 +2,7 @@
 
 This step-by-step tutorial helps you deploy a full Kubernetes Fury Cluster on a set of already existing VMs.
 
-> ☁️ If you prefer trying Fury in a cloud environment, check out the [Fury on EKS](../fury-on-eks) tutorial.
+> ☁️ If you prefer trying Fury in a cloud environment, check out the [Fury on EKS][fury-on-eks] tutorial.
 
 The goal of this tutorial is to introduce you to the main concepts of KFD and how to work with its tooling.
 
@@ -29,10 +29,10 @@ To follow this tutorial, you need:
 
 2. Clone the [fury getting started repository](https://github.com/sighupio/fury-getting-started) containing all the example code used in this tutorial:
 
-```bash
-git clone https://github.com/sighupio/fury-getting-started/
-cd fury-getting-started/fury-on-vms
-```
+    ```bash
+    git clone https://github.com/sighupio/fury-getting-started/
+    cd fury-getting-started/fury-on-vms
+    ```
 
 ## Step 1 - Install furyctl
 

--- a/legacy/fury-on-gke/README.md
+++ b/legacy/fury-on-gke/README.md
@@ -40,27 +40,27 @@ To follow this tutorial, you need:
 
 2. Clone the [fury getting started repository][fury-on-gke] containing all the example code used in this tutorial:
 
-```bash
-git clone https://github.com/sighupio/fury-getting-started
-cd fury-getting-started/fury-on-gke
-```
+    ```bash
+    git clone https://github.com/sighupio/fury-getting-started
+    cd fury-getting-started/fury-on-gke
+    ```
 
 3. Run the `fury-getting-started` docker image:
 
-```bash
-docker run -ti --rm \
-  -v $PWD:/demo \
-  registry.sighup.io/delivery/fury-getting-started
-```
+    ```bash
+    docker run -ti --rm \
+      -v $PWD:/demo \
+      registry.sighup.io/delivery/fury-getting-started
+    ```
 
 4. Set up your GCP credentials by exporting the following environment variables:
 
-```bash
-export GOOGLE_CREDENTIALS=<PATH_TO_YOUR_CREDENTIALS_JSON>
-export GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_CREDENTIALS
-export GOOGLE_PROJECT=<YOUR_PROJECT_NAME>
-export GOOGLE_REGION=<YOUR_REGION>
-```
+    ```bash
+    export GOOGLE_CREDENTIALS=<PATH_TO_YOUR_CREDENTIALS_JSON>
+    export GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_CREDENTIALS
+    export GOOGLE_PROJECT=<YOUR_PROJECT_NAME>
+    export GOOGLE_REGION=<YOUR_REGION>
+    ```
 
 💡 by default this guide uses `n1-standard-*` instances. Check that this type is available in the chosen region, for example, `europe-west6` (otherwise you'll have to adjust the various configuration files with a supported instance type).
 
@@ -139,80 +139,80 @@ Although this is a tutorial, it is always a good practice to use a remote Terraf
 
 1. You can manually create it using the `gcloud cli`:
 
-```bash
-gsutil mb gs://<GCS_BUCKET>
+    ```bash
+    gsutil mb gs://<GCS_BUCKET>
 
-# Enable versioning (recommended for terraform state)
-gsutil versioning set on gs://<GCS_BUCKET>
-```
+    # Enable versioning (recommended for terraform state)
+    gsutil versioning set on gs://<GCS_BUCKET>
+    ```
 
 2. Once created, uncomment the `spec.executor.state` block in the `/demo/infrastructure/bootstrap.yml` file:
 
-```yaml
-...
-executor:
-  state:
-    backend: gcs
-    config:
-      bucket: <GCS_BUCKET>
-      prefix: terraform/bootstrap
-```
+    ```yaml
+    ...
+    executor:
+      state:
+        backend: gcs
+        config:
+          bucket: <GCS_BUCKET>
+          prefix: terraform/bootstrap
+    ```
 
 3. Replace the `<GCS_BUCKET>` with the correct values from the previous commands:
 
-```yaml
-...
-executor:
-  state:
-    backend: gcs
-    config:
-      bucket: fury-demo-gke # example value
-      prefix: terraform/bootstrap
-```
+    ```yaml
+    ...
+    executor:
+      state:
+        backend: gcs
+        config:
+          bucket: fury-demo-gke # example value
+          prefix: terraform/bootstrap
+    ```
 
 #### Provision networking infrastructure
 
 1. Initialize the bootstrap provisioner:
 
-```bash
-cd infrastructure
-furyctl bootstrap init
-```
+    ```bash
+    cd infrastructure
+    furyctl bootstrap init
+    ```
 
-In case you run into errors, you can re-initialize the bootstrap provisioner by adding the `--reset` flag:
+    In case you run into errors, you can re-initialize the bootstrap provisioner by adding the `--reset` flag:
 
-```bash
-furyctl bootstrap init --reset
-```
+    ```bash
+    furyctl bootstrap init --reset
+    ```
 
 2. If the initialization succeeds, apply the bootstrap provisioner:
 
-```bash
-furyctl bootstrap apply
-```
+    ```bash
+    furyctl bootstrap apply
+    ```
 
-> 📝 This phase may take some minutes.
->
-> Logs are available at `/demo/infrastructure/bootstrap/logs/terraform.logs`.
+    > 📝 This phase may take some minutes.
+    >
+    > Logs are available at `/demo/infrastructure/bootstrap/logs/terraform.logs`.
 
 3. When the `furyctl bootstrap apply` completes, inspect the output:
 
-```bash
-...
-All the bootstrap components are up to date.
+    ```bash
+    ...
+    All the bootstrap components are up to date.
 
-VPC and VPN ready:
+    VPC and VPN ready:
 
-VPC: fury-gcp-demo
-Public Subnets  : [fury-gcp-demo-public-subnet-1]
-Private Subnets : [fury-gcp-demo-private-subnet-1]
-Cluster Subnet  : fury-gcp-demo-cluster-subnet
-  Pod Subnet    : fury-gcp-demo-cluster-pod-subnet
-  Service Subnet: fury-gcp-demo-cluster-service-subnet
+    VPC: fury-gcp-demo
+    Public Subnets  : [fury-gcp-demo-public-subnet-1]
+    Private Subnets : [fury-gcp-demo-private-subnet-1]
+    Cluster Subnet  : fury-gcp-demo-cluster-subnet
+      Pod Subnet    : fury-gcp-demo-cluster-pod-subnet
+      Service Subnet: fury-gcp-demo-cluster-service-subnet
 
-Your VPN instance IPs are: [35.242.223.13]
-...
-```
+    Your VPN instance IPs are: [35.242.223.13]
+    ...
+    ```
 
 In particular, have a look at VPC and subnets: these values are used in the cluster provisioning phase.
 
@@ -222,36 +222,36 @@ In the cluster provisioning phase, `furyctl` automatically deploys a battle-test
 
 1. Create the OpenVPN credentials with the `furyagent`:
 
-```bash
-furyagent configure openvpn-client \
-  --client-name fury \
-  --config /demo/infrastructure/bootstrap/secrets/furyagent.yml \
-  > fury.ovpn
-```
+    ```bash
+    furyagent configure openvpn-client \
+      --client-name fury \
+      --config /demo/infrastructure/bootstrap/secrets/furyagent.yml \
+      > fury.ovpn
+    ```
 
-> 🕵🏻‍♂️ [Furyagent][furyagent-repository] is a tool developed by SIGHUP to manage OpenVPN and SSH user access to the bastion host.
+    > 🕵🏻‍♂️ [Furyagent][furyagent-repository] is a tool developed by SIGHUP to manage OpenVPN and SSH user access to the bastion host.
 
 2. Check that the `fury` user is now listed:
 
-```bash
-furyagent configure openvpn-client --list \
---config /demo/infrastructure/bootstrap/secrets/furyagent.yml
-```
+    ```bash
+    furyagent configure openvpn-client --list \
+    --config /demo/infrastructure/bootstrap/secrets/furyagent.yml
+    ```
 
-Output:
+    Output:
 
-```console
-2021-06-07 14:37:52.169664 I | storage.go:146: Item pki/vpn-client/fury.crt found [size: 1094]
-2021-06-07 14:37:52.169850 I | storage.go:147: Saving item pki/vpn-client/fury.crt ...
-2021-06-07 14:37:52.265797 I | storage.go:146: Item pki/vpn/ca.crl found [size: 560]
-2021-06-07 14:37:52.265879 I | storage.go:147: Saving item pki/vpn/ca.crl ...
-+------+------------+------------+---------+--------------------------------+
-| USER | VALID FROM |  VALID TO  | EXPIRED |            REVOKED             |
-+------+------------+------------+---------+--------------------------------+
-| fury | 2021-06-07 | 2022-06-07 | false   | false 0001-01-01 00:00:00      |
-|      |            |            |         | +0000 UTC                      |
-+------+------------+------------+---------+--------------------------------+
-```
+    ```bash
+    2021-06-07 14:37:52.169664 I | storage.go:146: Item pki/vpn-client/fury.crt found [size: 1094]
+    2021-06-07 14:37:52.169850 I | storage.go:147: Saving item pki/vpn-client/fury.crt ...
+    2021-06-07 14:37:52.265797 I | storage.go:146: Item pki/vpn/ca.crl found [size: 560]
+    2021-06-07 14:37:52.265879 I | storage.go:147: Saving item pki/vpn/ca.crl ...
+    +------+------------+------------+---------+--------------------------------+
+    | USER | VALID FROM |  VALID TO  | EXPIRED |            REVOKED             |
+    +------+------------+------------+---------+--------------------------------+
+    | fury | 2021-06-07 | 2022-06-07 | false   | false 0001-01-01 00:00:00      |
+    |      |            |            |         | +0000 UTC                      |
+    +------+------------+------------+---------+--------------------------------+
+    ```
 
 3. Open the `fury.ovpn` file with any OpenVPN Client.
 
@@ -307,26 +307,26 @@ Open the file with a text editor and replace:
 
 1. Initialize the cluster provisioner:
 
-```bash
-furyctl cluster init
-```
+    ```bash
+    furyctl cluster init
+    ```
 
 2. Create GKE cluster:
 
-```bash
-furyctl cluster apply
-```
+    ```bash
+    furyctl cluster apply
+    ```
 
-> 📝 This phase may take some minutes.
->
-> Logs are available at `/demo/infrastructure/cluster/logs/terraform.logs`.
+    > 📝 This phase may take some minutes.
+    >
+    > Logs are available at `/demo/infrastructure/cluster/logs/terraform.logs`.
 
 3. When the `furyctl cluster apply` completes, test the connection with the cluster:
 
-```bash
-export KUBECONFIG=/demo/infrastructure/cluster/secrets/kubeconfig
-kubectl get nodes
-```
+    ```bash
+    export KUBECONFIG=/demo/infrastructure/cluster/secrets/kubeconfig
+    kubectl get nodes
+    ```
 
 ## Step 2 - Download Fury modules
 
@@ -363,80 +363,80 @@ modules:
 
 1. Download the Fury modules with `furyctl`:
 
-```bash
-cd /demo/
-furyctl vendor -H
-```
+    ```bash
+    cd /demo/
+    furyctl vendor -H
+    ```
 
 2. Inspect the downloaded modules in the `vendor` folder:
 
-```bash
-tree -d /demo/vendor -L 3
-```
+    ```bash
+    tree -d /demo/vendor -L 3
+    ```
 
-Output:
+    Output:
 
-```bash
-$ tree -d vendor -L 3
+    ```bash
+    $ tree -d vendor -L 3
 
-vendor
-├── katalog
-│   ├── dr
-│   │   ├── tests
-│   │   └── velero
-│   ├── ingress
-│   │   ├── cert-manager
-│   │   ├── dual-nginx
-│   │   ├── external-dns
-│   │   ├── forecastle
-│   │   ├── nginx
-│   │   └── tests
-│   ├── logging
-│   │   ├── cerebro
-│   │   ├── configs
-│   │   ├── logging-operated
-│   │   ├── logging-operator
-│   │   ├── loki-configs
-│   │   ├── loki-distributed
-│   │   ├── minio-ha
-│   │   ├── opensearch-dashboards
-│   │   ├── opensearch-single
-│   │   ├── opensearch-triple
-│   │   └── tests
-│   ├── monitoring
-│   │   ├── aks-sm
-│   │   ├── alertmanager-operated
-│   │   ├── blackbox-exporter
-│   │   ├── configs
-│   │   ├── eks-sm
-│   │   ├── gke-sm
-│   │   ├── grafana
-│   │   ├── karma
-│   │   ├── kube-proxy-metrics
-│   │   ├── kube-state-metrics
-│   │   ├── kubeadm-sm
-│   │   ├── node-exporter
-│   │   ├── prometheus-adapter
-│   │   ├── prometheus-operated
-│   │   ├── prometheus-operator
-│   │   ├── tests
-│   │   ├── thanos
-│   │   └── x509-exporter
-│   ├── networking
-│   │   ├── calico
-│   │   ├── ip-masq
-│   │   ├── tests
-│   │   └── tigera
-│   └── opa
-│       ├── gatekeeper
-│       └── tests
-└── modules
-    └── dr
-        ├── aws-velero
-        ├── azure-velero
-        └── gcp-velero
+    vendor
+    ├── katalog
+    │   ├── dr
+    │   │   ├── tests
+    │   │   └── velero
+    │   ├── ingress
+    │   │   ├── cert-manager
+    │   │   ├── dual-nginx
+    │   │   ├── external-dns
+    │   │   ├── forecastle
+    │   │   ├── nginx
+    │   │   └── tests
+    │   ├── logging
+    │   │   ├── cerebro
+    │   │   ├── configs
+    │   │   ├── logging-operated
+    │   │   ├── logging-operator
+    │   │   ├── loki-configs
+    │   │   ├── loki-distributed
+    │   │   ├── minio-ha
+    │   │   ├── opensearch-dashboards
+    │   │   ├── opensearch-single
+    │   │   ├── opensearch-triple
+    │   │   └── tests
+    │   ├── monitoring
+    │   │   ├── aks-sm
+    │   │   ├── alertmanager-operated
+    │   │   ├── blackbox-exporter
+    │   │   ├── configs
+    │   │   ├── eks-sm
+    │   │   ├── gke-sm
+    │   │   ├── grafana
+    │   │   ├── karma
+    │   │   ├── kube-proxy-metrics
+    │   │   ├── kube-state-metrics
+    │   │   ├── kubeadm-sm
+    │   │   ├── node-exporter
+    │   │   ├── prometheus-adapter
+    │   │   ├── prometheus-operated
+    │   │   ├── prometheus-operator
+    │   │   ├── tests
+    │   │   ├── thanos
+    │   │   └── x509-exporter
+    │   ├── networking
+    │   │   ├── calico
+    │   │   ├── ip-masq
+    │   │   ├── tests
+    │   │   └── tigera
+    │   └── opa
+    │       ├── gatekeeper
+    │       └── tests
+    └── modules
+        └── dr
+            ├── aws-velero
+            ├── azure-velero
+            └── gcp-velero
 
-```
+    ```
 
 ## Step 3 - Installation
 
@@ -448,11 +448,11 @@ First of all, we need to initialize the additional Terraform project to create r
 
 Inside the repository, you can find a Terraform file at `/demo/terraform/main.tf`. Edit this file and change the values for the GCS bucket that will store the Terraform state for the new resources:
 
-```terraform
+```hcl
 terraform {
 #   backend "s3" {
 #     bucket = <GCS_BUCKET>
-#     key    = <MY_KEY> 
+#     key    = <MY_KEY>
 #     region = <GCS_BUCKET_REGION>
 #   }
   required_version = ">= 0.15.4"
@@ -466,7 +466,7 @@ terraform {
 
 Then, create a file `terraform.tfvars` with the following content (change the values accordingly to your environment):
 
-```terraform
+```hcl
 velero_bucket_name = "velero-gke-demo-sa"
 ```
 
@@ -562,21 +562,21 @@ To access the ingresses more easily via the browser, configure your local DNS to
 
 1. Get the address of the internal load balancer:
 
-```bash
-dig $(kubectl get svc ingress-nginx -n ingress-nginx --no-headers | awk '{print $4}')
-```
+    ```bash
+    dig $(kubectl get svc ingress-nginx -n ingress-nginx --no-headers | awk '{print $4}')
+    ```
 
-Output:
+    Output:
 
-```bash
-10.1.0.5
-```
+    ```bash
+    10.1.0.5
+    ```
 
-3. Add the following line to your local `/etc/hosts` (not the container's):
+2. Add the following line to your local `/etc/hosts` (not the container's):
 
-```bash
-<LB-IP-ADDRESS> directory.fury.info prometheus.fury.info alertmanager.fury.info opensearch-dashboards.fury.info grafana.fury.info
-```
+    ```bash
+    <LB-IP-ADDRESS> directory.fury.info prometheus.fury.info alertmanager.fury.info opensearch-dashboards.fury.info grafana.fury.info
+    ```
 
 Now, you can reach the ingresses directly from your browser.
 
@@ -656,15 +656,15 @@ This is what you should see:
 
 1. Create a backup with the `velero` command-line utility:
 
-```bash
-velero backup create --from-schedule manifests test -n kube-system
-```
+    ```bash
+    velero backup create --from-schedule manifests test -n kube-system
+    ```
 
 2. Check the backup status:
 
-```bash
-velero backup get -n kube-system
-```
+    ```bash
+    velero backup get -n kube-system
+    ```
 
 ### (optional) Enforce a Policy with OPA Gatekeeper
 
@@ -682,7 +682,7 @@ Gatekeeper runs as a Validating Admission Webhook, meaning that all the requests
 
 If you list the pods in the `default` namespace, the list it should be empty, confirming that the pod creation was actually rejected:
 
-```console
+```bash
 $ kubectl get pods -n default
 No resources found in default namespace.
 ```
@@ -695,7 +695,7 @@ kubectl run --image busybox bad-pod -n kube-system
 
 Output should be:
 
-```console
+```bash
 pod/bad-pod created
 ```
 
@@ -707,61 +707,61 @@ Clean up the demo environment:
 
 1. Delete the namespaces containing external resources like volumes and load balancers:
 
-```bash
-kubectl delete namespace logging monitoring ingress-nginx
-```
+    ```bash
+    kubectl delete namespace logging monitoring ingress-nginx
+    ```
 
-Wait until the namespaces are completely deleted, or that:
+    Wait until the namespaces are completely deleted, or that:
 
-```bash
-kubectl get pvc -A
-# and 
-kubectl get svc -A
-```
+    ```bash
+    kubectl get pvc -A
+    # and
+    kubectl get svc -A
+    ```
 
-return no result for pvc and no LoadBalancer for svc.
+    return no result for pvc and no LoadBalancer for svc.
 
 2. Destroy the additional Terraform resources used by Velero:
 
-```bash
-cd /demo/terraform/
-terraform destroy
-```
+    ```bash
+    cd /demo/terraform/
+    terraform destroy
+    ```
 
 3. Destroy GKE cluster:
 
-```bash
-# Destroy cluster
-cd /demo/infrastructure
-furyctl cluster destroy
-```
+    ```bash
+    # Destroy cluster
+    cd /demo/infrastructure
+    furyctl cluster destroy
+    ```
 
 4. Destroy the firewall-rules we have made for nginx ingress:
-  
-```bash
-cd /demo/infrastructure
-make delete-firewall-rule FIREWALL_RULE_NAME=allow-nginx-ingress-admission-webhook
-```
+
+    ```bash
+    cd /demo/infrastructure
+    make delete-firewall-rule FIREWALL_RULE_NAME=allow-nginx-ingress-admission-webhook
+    ```
 
 5. Destroy network infrastructure (remember to disconnect from the VPN before deleting):
 
-```bash
-cd /demo/infrastructure
-furyctl bootstrap destroy
-```
+    ```bash
+    cd /demo/infrastructure
+    furyctl bootstrap destroy
+    ```
 
 6. (Optional) Destroy the S3 bucket holding the Terraform state
 
-```bash
-gsutil -m rm -r gs://<GCS_BUCKET>/terraform
-gsutil rb gs://<GCS_BUCKET>
-```
+    ```bash
+    gsutil -m rm -r gs://<GCS_BUCKET>/terraform
+    gsutil rb gs://<GCS_BUCKET>
+    ```
 
 7. Exit from the docker container:
 
-```bash
-exit
-```
+    ```bash
+    exit
+    ```
 
 ## Conclusions
 
@@ -786,13 +786,11 @@ More about Fury:
 
 <!-- Links -->
 
-[fury-getting-started-repository]: https://github.com/sighupio/fury-getting-started/
 [fury-getting-started-dockerfile]: https://github.com/sighupio/fury-getting-started/blob/main/utils/docker/Dockerfile
 
 [fury-on-minikube]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-minikube
 [fury-on-gke]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-gke
 [fury-on-eks]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-eks
-[fury-on-ovhcloud]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-ovhcloud
 
 [fury-docs]: https://docs.kubernetesfury.com
 

--- a/legacy/fury-on-ovhcloud/README.md
+++ b/legacy/fury-on-ovhcloud/README.md
@@ -224,9 +224,9 @@ source ./ovhrc
 
 We use Terraform to deploy the network and the Managed Kubernetes Cluster. A `variables.tfvars` variable file is present with some default values that you can use as this or change the values if needed:
 
-```terraform
+```hcl
 # Region
-  
+
 region = "GRA7"
 
 # Network - Private Network
@@ -297,7 +297,6 @@ export KUBECONFIG="$PWD/kubeconfig"
 
 Your `kubectl` CLI is ready to use
 
-
 ## Step 2 - Installation
 
 In this section, you use `furyctl` to download the monitoring, logging, and ingress modules of the Fury distribution.
@@ -324,60 +323,60 @@ bases:
 
 1. Download the Fury modules with `furyctl`:
 
-```bash
-furyctl vendor -H
-```
+    ```bash
+    furyctl vendor -H
+    ```
 
 2. Inspect the downloaded modules in the `vendor` folder:
 
-```bash
-tree -d vendor -L 3
-```
+    ```bash
+    tree -d vendor -L 3
+    ```
 
-Output:
+    Output:
 
-```bash
-$ tree -d vendor -L 3
+    ```bash
+    $ tree -d vendor -L 3
 
-vendor
-└── katalog
-    ├── ingress
-    │   ├── cert-manager
-    │   ├── dual-nginx
-    │   ├── external-dns
-    │   ├── forecastle
-    │   ├── nginx
-    │   └── tests
-    ├── logging
-    │   ├── cerebro
-    │   ├── configs
-    │   ├── logging-operated
-    │   ├── logging-operator
-    │   ├── loki-configs
-    │   ├── loki-single
-    │   ├── opensearch-dashboards
-    │   ├── opensearch-single
-    │   ├── opensearch-triple
-    │   └── tests
-    └── monitoring
-        ├── aks-sm
-        ├── alertmanager-operated
-        ├── blackbox-exporter
-        ├── configs
-        ├── eks-sm
-        ├── gke-sm
-        ├── grafana
-        ├── kubeadm-sm
-        ├── kube-proxy-metrics
-        ├── kube-state-metrics
-        ├── node-exporter
-        ├── prometheus-adapter
-        ├── prometheus-operated
-        ├── prometheus-operator
-        ├── tests
-        ├── thanos
-        └── x509-exporter
-```
+    vendor
+    └── katalog
+        ├── ingress
+        │   ├── cert-manager
+        │   ├── dual-nginx
+        │   ├── external-dns
+        │   ├── forecastle
+        │   ├── nginx
+        │   └── tests
+        ├── logging
+        │   ├── cerebro
+        │   ├── configs
+        │   ├── logging-operated
+        │   ├── logging-operator
+        │   ├── loki-configs
+        │   ├── loki-single
+        │   ├── opensearch-dashboards
+        │   ├── opensearch-single
+        │   ├── opensearch-triple
+        │   └── tests
+        └── monitoring
+            ├── aks-sm
+            ├── alertmanager-operated
+            ├── blackbox-exporter
+            ├── configs
+            ├── eks-sm
+            ├── gke-sm
+            ├── grafana
+            ├── kubeadm-sm
+            ├── kube-proxy-metrics
+            ├── kube-state-metrics
+            ├── node-exporter
+            ├── prometheus-adapter
+            ├── prometheus-operated
+            ├── prometheus-operator
+            ├── tests
+            ├── thanos
+            └── x509-exporter
+    ```
 
 ### Kustomize project
 
@@ -452,15 +451,15 @@ To access the ingresses more easily via the browser, configure your local DNS to
 
 1. Get the address of the external load balancer:
 
-```bash
-kubectl get svc -n ingress-nginx ingress-nginx -ojsonpath='{.spec.externalIPs[*]}'
-```
+    ```bash
+    kubectl get svc -n ingress-nginx ingress-nginx -ojsonpath='{.spec.externalIPs[*]}'
+    ```
 
 2. Add the following line to your machine's `/etc/hosts` (not the container's):
 
-```bash
-<EXTERNAL_IP> forecastle.fury.info cerebro.fury.info opensearch-dashboards.fury.info grafana.fury.info
-```
+    ```bash
+    <EXTERNAL_IP> forecastle.fury.info cerebro.fury.info opensearch-dashboards.fury.info grafana.fury.info
+    ```
 
 Now, you can reach the ingresses directly from your browser.
 
@@ -570,20 +569,17 @@ More about Fury:
 - [Fury Documentation][fury-docs]
 
 <!-- Links -->
-[fury-getting-started-repository]: https://github.com/sighupio/fury-getting-started/
-[fury-getting-started-dockerfile]: https://github.com/sighupio/fury-getting-started/blob/main/utils/docker/Dockerfile
-
 [fury-on-minikube]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-minikube
 [fury-on-gke]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-gke
 [fury-on-eks]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-eks
 
-[furyagent-repository]: https://github.com/sighupio/furyagent
-
 [fury-docs]: https://docs.kubernetesfury.com
-[opa-module-docs]: https://docs.kubernetesfury.com/docs/modules/opa/overview
 
 <!-- Images -->
 <!-- `media` here is a branch. We used to store all images in that branch and reference them from other branches -->
 [grafana-screenshot]: https://github.com/sighupio/fury-getting-started/blob/media/grafana.png?raw=true
 [opensearch-dashboards-screenshot]: https://github.com/sighupio/fury-getting-started/blob/main/utils/images/opensearch_dashboards.png?raw=true
 [forecastle-eks-screenshot]: https://github.com/sighupio/fury-getting-started/blob/main/utils/images/forecastle_eks.png?raw=true
+[opensearch-dashboards-welcome]: https://github.com/sighupio/fury-getting-started/blob/main/utils/images/opensearch-dashboards_welcome.png?raw=true
+[opensearch-dashboards-discover]: https://github.com/sighupio/fury-getting-started/blob/main/utils/images/opensearch-dashboards_discover.png?raw=true
+[opensearch-dashboards-index]: https://github.com/sighupio/fury-getting-started/blob/main/utils/images/opensearch-dashboards_index.png?raw=true

--- a/legacy/fury-on-talos/README.md
+++ b/legacy/fury-on-talos/README.md
@@ -20,7 +20,7 @@ This tutorial will cover the following topics:
 5. Explore some of the Features
 6. Teardown the environment
 
-> ☁️ If you prefer trying Fury in a cloud environment, check out the [Fury on EKS](../fury-on-eks) tutorial or the [Fury on GKE](../fury-on-gke) tutorial.
+> ☁️ If you prefer trying Fury in a cloud environment, check out the [Fury on EKS][fury-on-eks] tutorial or the [Fury on GKE][fury-on-gke] tutorial.
 
 ## Prerequisites
 
@@ -42,28 +42,28 @@ To follow this tutorial you will need:
 
 2. Clone the [fury getting started repository][fury-getting-started-repository] containing all the example code used in this tutorial:
 
-```bash
-git clone https://github.com/sighupio/fury-getting-started/
-cd fury-getting-started/fury-on-talos
-```
+    ```bash
+    git clone https://github.com/sighupio/fury-getting-started/
+    cd fury-getting-started/fury-on-talos
+    ```
 
 3. Download `talosctl`
 
-For `amd64` architectures:
+    For `amd64` architectures:
 
-```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/v1.0.5/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
-chmod +x /usr/local/bin/talosctl
-```
+    ```bash
+    curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/v1.0.5/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+    chmod +x /usr/local/bin/talosctl
+    ```
 
-For Linux and darwin operating systems `talosctl` is also available for the `arm64` processor architecture:
+    For Linux and darwin operating systems `talosctl` is also available for the `arm64` processor architecture:
 
-```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/v1.0.5/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-arm64
-chmod +x /usr/local/bin/talosctl
-```
+    ```bash
+    curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/v1.0.5/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-arm64
+    chmod +x /usr/local/bin/talosctl
+    ```
 
-> See the [offciial documentation for talosctl][talosctl-docs] for more details.
+    > See the [offcial documentation for talosctl][talosctl-docs] for more details.
 
 You are all set to start the tutorial 🚀
 
@@ -97,107 +97,108 @@ Considering the previous requirements, we can proceed to the first step: the clu
 
 1. Create the Talos Cluster using the flags mentioned before:
 
-```bash
-talosctl cluster create --kubernetes-version 1.23.6 --cpus-workers 4 --memory-workers 4096 --exposed-ports 31080:31080/tcp,31443:31443/tcp --config-patch-worker @infrastructure/talos-worker-patch.yaml
-```
+    ```bash
+    talosctl cluster create --kubernetes-version 1.23.6 --cpus-workers 4 --memory-workers 4096    --exposed-ports 31080:31080/tcp,31443:31443/tcp --config-patch-worker @infrastructure/  talos-worker-patch.yaml
+    ```
 
-Expected output:
-```bash
-validating CIDR and reserving IPs
-generating PKI and tokens
-creating network talos-default
-creating master nodes
-creating worker nodes
-waiting for API
-bootstrapping cluster
-waiting for etcd to be healthy: OK
-waiting for apid to be ready: OK
-waiting for kubelet to be healthy: OK
-waiting for all nodes to finish boot sequence: OK
-waiting for all k8s nodes to report: OK
-waiting for all k8s nodes to report ready: OK
-waiting for all control plane components to be ready: OK
-waiting for kube-proxy to report ready: OK
-waiting for coredns to report ready: OK
-waiting for all k8s nodes to report schedulable: OK
+    Expected output:
 
-merging kubeconfig into "/Users/ralgozino/.kube/config"
-PROVISIONER       docker
-NAME              talos-default
-NETWORK NAME      talos-default
-NETWORK CIDR      10.5.0.0/24
-NETWORK GATEWAY   10.5.0.1
-NETWORK MTU       1500
+    ```bash
+    validating CIDR and reserving IPs
+    generating PKI and tokens
+    creating network talos-default
+    creating master nodes
+    creating worker nodes
+    waiting for API
+    bootstrapping cluster
+    waiting for etcd to be healthy: OK
+    waiting for apid to be ready: OK
+    waiting for kubelet to be healthy: OK
+    waiting for all nodes to finish boot sequence: OK
+    waiting for all k8s nodes to report: OK
+    waiting for all k8s nodes to report ready: OK
+    waiting for all control plane components to be ready: OK
+    waiting for kube-proxy to report ready: OK
+    waiting for coredns to report ready: OK
+    waiting for all k8s nodes to report schedulable: OK
 
-NODES:
+    merging kubeconfig into "/Users/ralgozino/.kube/config"
+    PROVISIONER       docker
+    NAME              talos-default
+    NETWORK NAME      talos-default
+    NETWORK CIDR      10.5.0.0/24
+    NETWORK GATEWAY   10.5.0.1
+    NETWORK MTU       1500
 
-NAME                      TYPE           IP         CPU    RAM      DISK
-/talos-default-master-1   controlplane   10.5.0.2   2.00   2.1 GB   -
-/talos-default-worker-1   worker         10.5.0.3   4.00   4.3 GB   -
-```
+    NODES:
+
+    NAME                      TYPE           IP         CPU    RAM      DISK
+    /talos-default-master-1   controlplane   10.5.0.2   2.00   2.1 GB   -
+    /talos-default-worker-1   worker         10.5.0.3   4.00   4.3 GB   -
+    ```
 
 2. By default `talosctl` will add a new context to your current kubeconfig. For simplicity, let's export the kubeconfig to a file in the `infrastructure` folder:
 
-```bash
-talosctl --nodes 10.5.0.2 kubeconfig infrastructure/
-```
+    ```bash
+    talosctl --nodes 10.5.0.2 kubeconfig infrastructure/
+    ```
 
->⚠️ Make sure to use the master's IP as the --nodes flag value in the previous command
+    >⚠️ Make sure to use the master's IP as the --nodes flag value in the previous command
 
 3. Run the `fury-getting-started` docker image:
 
-```bash
-docker run -ti --rm \
-  -v $PWD:/demo \
-  --env KUBECONFIG=/demo/infrastructure/kubeconfig \
-  --net=host \
-   registry.sighup.io/delivery/fury-getting-started
-```
+    ```bash
+    docker run -ti --rm \
+      -v $PWD:/demo \
+      --env KUBECONFIG=/demo/infrastructure/kubeconfig \
+      --net=host \
+       registry.sighup.io/delivery/fury-getting-started
+    ```
 
->ℹ️ From now on all commands in this guide assume to be run inside this container unless otherwise specified.
+    >ℹ️ From now on all commands in this guide assume to be run inside this container unless otherwise specified.
 
 4. Test the connection to the cluster:
 
-```bash
-kubectl get nodes
-```
+    ```bash
+    kubectl get nodes
+    ```
 
-Output:
+    Output:
 
-```bash
-NAME                     STATUS   ROLES                  AGE   VERSION
-talos-default-master-1   Ready    control-plane,master   96s   v1.23.6
-talos-default-worker-1   Ready    <none>                 92s   v1.23.6
-```
+    ```bash
+    NAME                     STATUS   ROLES                  AGE   VERSION
+    talos-default-master-1   Ready    control-plane,master   96s   v1.23.6
+    talos-default-worker-1   Ready    <none>                 92s   v1.23.6
+    ```
 
 5. Now that we have the cluster up and running, we can install the `local-path` storage. Run the following command to install it:
 
-```bash
-kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.22/deploy/local-path-storage.yaml
-```
+    ```bash
+    kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.22/deploy/local-path-storage.yaml
+    ```
 
 6. Make the new storage class `local-path` the default one:
 
-```bash
-kubectl patch storageclass local-path -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
-```	
+    ```bash
+    kubectl patch storageclass local-path -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+    ```
 
 7. Check that the `local-path-storage` is working properly.
 
-Check the logs, with the following command:
+    Check the logs, with the following command:
 
-```bash
-kubectl -n local-path-storage logs -f -l app=local-path-provisioner
-```
+    ```bash
+    kubectl -n local-path-storage logs -f -l app=local-path-provisioner
+    ```
 
-you should get something like this:
+    you should get something like this:
 
-```log
-time="2022-05-26T08:46:13Z" level=debug msg="Applied config: {\"nodePathMap\":[{\"node\":\"DEFAULT_PATH_FOR_NON_LISTED_NODES\",\"paths\":[\"/opt/local-path-provisioner\"]}]}" 
-time="2022-05-26T08:46:13Z" level=debug msg="Provisioner started" 
-I0526 08:46:13.142016       1 controller.go:773] Starting provisioner controller rancher.io/local-path_local-path-provisioner-64d5bc6b74-dlqxz_62c217e5-a519-40e5-897b-d82464448012!
-I0526 08:46:13.243167       1 controller.go:822] Started provisioner controller rancher.io/local-path_local-path-provisioner-64d5bc6b74-dlqxz_62c217e5-a519-40e5-897b-d82464448012!
-```
+    ```log
+    time="2022-05-26T08:46:13Z" level=debug msg="Applied config: {\"nodePathMap\":[{\"node\":\"DEFAULT_PATH_FOR_NON_LISTED_NODES\",\"paths\":[\"/opt/local-path-provisioner\"]}]}"
+    time="2022-05-26T08:46:13Z" level=debug msg="Provisioner started"
+    I0526 08:46:13.142016       1 controller.go:773] Starting provisioner controller rancher.io/local-path_local-path-provisioner-64d5bc6b74-dlqxz_62c217e5-a519-40e5-897b-d82464448012!
+    I0526 08:46:13.243167       1 controller.go:822] Started provisioner controller rancher.io/local-path_local-path-provisioner-64d5bc6b74-dlqxz_62c217e5-a519-40e5-897b-d82464448012!
+    ```
 
 ## Step 2 - Getting KFD modules
 
@@ -227,7 +228,7 @@ bases:
   - name: monitoring/configs
   - name: monitoring/kube-state-metrics
   - name: monitoring/node-exporter
-  
+
   - name: logging/elasticsearch-single
   - name: logging/cerebro
   - name: logging/curator
@@ -258,45 +259,45 @@ Now that we have a `Furyfile.yml`, we can proceed to download the modules.
 
 1. Run the following command to download the modules specified by the Furyfile:
 
-```bash
-cd /demo
-furyctl vendor -H
-```
+    ```bash
+    cd /demo
+    furyctl vendor -H
+    ```
 
-> ℹ️ the `-H` flag tells `furyctl` to use HTTP(S) instead of SSH to download the modules from GitHub.
+    > ℹ️ the `-H` flag tells `furyctl` to use HTTP(S) instead of SSH to download the modules from GitHub.
 
 2. Inspect the downloaded modules in the `vendor` folder:
 
-```bash
-tree -d /demo/vendor -L 3
-```
+    ```bash
+    tree -d /demo/vendor -L 3
+    ```
 
-Output:
+    Output:
 
-```bash
-/demo/vendor
-└── katalog
-    ├── ingress
-    │   ├── forecastle
-    │   └── nginx
-    ├── logging
-    │   ├── cerebro
-    │   ├── curator
-    │   ├── elasticsearch-single
-    │   ├── fluentd
-    │   └── kibana
-    └── monitoring
-        ├── alertmanager-operated
-        ├── configs
-        ├── grafana
-        ├── kube-state-metrics
-        ├── kubeadm-sm
-        ├── node-exporter
-        ├── prometheus-operated
-        └── prometheus-operator
+    ```bash
+    /demo/vendor
+    └── katalog
+        ├── ingress
+        │   ├── forecastle
+        │   └── nginx
+        ├── logging
+        │   ├── cerebro
+        │   ├── curator
+        │   ├── elasticsearch-single
+        │   ├── fluentd
+        │   └── kibana
+        └── monitoring
+            ├── alertmanager-operated
+            ├── configs
+            ├── grafana
+            ├── kube-state-metrics
+            ├── kubeadm-sm
+            ├── node-exporter
+            ├── prometheus-operated
+            └── prometheus-operator
 
-19 directories
-```
+    19 directories
+    ```
 
 ## Step 3 - Installation
 
@@ -447,17 +448,17 @@ This is what you should see:
 
 1. Stop the docker container that we've been using to run the commands:
 
-```bash
-# Execute this command inside the Docker container
-exit
-```
+    ```bash
+    # Execute this command inside the Docker container
+    exit
+    ```
 
 2. Delete the talos cluster:
 
-```bash
-# Execute these commands from your local system, outside the Docker container
-talosctl cluster destroy
-```
+    ```bash
+    # Execute these commands from your local system, outside the Docker container
+    talosctl cluster destroy
+    ```
 
 ## Conclusions
 
@@ -488,7 +489,6 @@ More about Fury:
 [talosctl-docs]: https://www.talos.dev/v1.0/reference/cli/
 [fury-getting-started-dockerfile]: https://github.com/sighupio/fury-getting-started/blob/main/utils/docker/Dockerfile
 [rancher-local-path]: https://github.com/rancher/local-path-provisioner
-[furyctl-repo]: https://github.com/sighupio/furyctl
 [furyctl-docs]: https://docs.kubernetesfury.com/docs/infrastructure/furyctl
 
 [kfd-docs-modules]: https://docs.kubernetesfury.com/docs/modules/
@@ -501,10 +501,8 @@ More about Fury:
 [fury-on-eks]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-eks
 [fury-on-gke]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-gke
 [fury-on-ovhcloud]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-ovhcloud
-[furyagent-repository]: https://github.com/sighupio/furyagent
 
 <!-- Images -->
 [kibana-screenshot]: https://github.com/sighupio/fury-getting-started/blob/media/kibana.png?raw=true
 [grafana-screenshot]: https://github.com/sighupio/fury-getting-started/blob/media/grafana.png?raw=true
-[cerebro-screenshot]: https://github.com/sighupio/fury-getting-started/blob/media/cerebro.png?raw=true
 [forecastle-screenshot]: https://github.com/sighupio/fury-getting-started/blob/media/forecastle.png?raw=true


### PR DESCRIPTION
- fix indentation problems in ordered lists
- insert missing blank lines where required
- remove excessive blank lines
- remove trailing spaces
- remove unused link definitions
- use already existing link definitions instead of repeating them
- create link definitions where missing
- avoid synonyms for code snippet languages (eg: replace `console` with `bash`)