### PR TITLE
Keep a uniform style for furyctl installation instructions

### DIFF
--- a/fury-on-eks/README.md
+++ b/fury-on-eks/README.md
@@ -34,7 +34,7 @@ To follow this tutorial, you need:
     cd /tmp/fury-getting-started/fury-on-eks
     ```
 
-3. Install `furyctl` binary: https://github.com/sighupio/furyctl#installation
+3. Install `furyctl` binary following the instructions in [furyctl's documentation][furyctl-installation].
 
 4. Setup your AWS credentials by exporting the following environment variables:
 
@@ -542,7 +542,7 @@ More about Fury:
 
 [fury-on-minikube]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-minikube
 [fury-on-vms]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-vms
-
+[furyctl-installation]: https://github.com/sighupio/furyctl#installation
 [fury-docs]: https://docs.kubernetesfury.com
 [opa-module-docs]: https://docs.kubernetesfury.com/docs/modules/opa/overview
 

--- a/fury-on-minikube/README.md
+++ b/fury-on-minikube/README.md
@@ -61,7 +61,7 @@ cd fury-getting-started/fury-on-minikube
 
 ## Step 3 - Install furyctl
 
-Install `furyctl` binary: https://github.com/sighupio/furyctl#installation version `>=0.29.0`.
+Install `furyctl` binary following the instructions in [furyctl's documentation][furyctl-installation].
 
 ## Step 3 - Installation
 
@@ -300,7 +300,7 @@ More about Fury:
 <!-- Links -->
 [fury-on-eks]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-eks
 [fury-on-vms]: https://github.com/sighupio/fury-getting-started/tree/main/fury-on-vms
-
+[furyctl-installation]: https://github.com/sighupio/furyctl#installation
 [fury-docs]: https://docs.kubernetesfury.com
 
 <!-- Images -->

--- a/fury-on-vms/README.md
+++ b/fury-on-vms/README.md
@@ -36,7 +36,7 @@ To follow this tutorial, you need:
 
 ## Step 1 - Install furyctl
 
-Install `furyctl` binary following the instructions in [furyctl's GitHub repository][furyctl-installation].
+Install `furyctl` binary following the instructions in [furyctl's documentation][furyctl-installation].
 
 We recommend to always install the latest version available. Latest versions are compatible with previous versions of the distribution. This guide assumes that furyctl version is at least 0.29.5. You can check with the following command:
 


### PR DESCRIPTION
Provide uniform style and text for furyctl's installation instruction links. This will also help keep the pull script of the documentation site cleaner, as it will need fewer customizations specific to each tutorial.