### PR TITLE
fix: add missing nginx key to furyctl manifests

### DIFF
--- a/distro-on-eks/README.md
+++ b/distro-on-eks/README.md
@@ -219,6 +219,8 @@ The Distribution section of the `furyctl.yaml` file contains the following param
     modules:
       ingress:
         baseDomain: internal.demo.example.dev
+        nginx:
+          type: none
         haproxy:
           type: dual
           tls:

--- a/distro-on-eks/furyctl.yaml
+++ b/distro-on-eks/furyctl.yaml
@@ -99,6 +99,8 @@ spec:
     modules:
       ingress:
         baseDomain: internal.demo.example.dev
+        nginx:
+          type: none
         haproxy:
           type: dual
           tls:

--- a/distro-on-minikube/README.md
+++ b/distro-on-minikube/README.md
@@ -83,6 +83,8 @@ spec:
         type: none
       ingress:
         baseDomain: demo.example.internal
+        nginx:
+          type: none
         haproxy:
           type: single
           tls:

--- a/distro-on-minikube/furyctl.yaml
+++ b/distro-on-minikube/furyctl.yaml
@@ -17,6 +17,8 @@ spec:
         type: none
       ingress:
         baseDomain: demo.example.internal
+        nginx:
+          type: none
         haproxy:
           type: single
           tls:

--- a/distro-on-vms/README.md
+++ b/distro-on-vms/README.md
@@ -256,6 +256,8 @@ spec:
     modules:
       ingress:
         baseDomain: sighup.example.tld
+        nginx:
+          type: none
         haproxy:
           type: single
           tls:
@@ -287,6 +289,8 @@ To correctly configure the cert-manager clusterIssuer we need to put a valid con
 >    modules:
 >      ingress:
 >        baseDomain: sighup.example.tld
+>        nginx:
+>          type: none
 >        haproxy:
 >          type: single
 >          tls:

--- a/distro-on-vms/furyctl.yaml
+++ b/distro-on-vms/furyctl.yaml
@@ -61,6 +61,8 @@ spec:
       # This section contains all the configurations for the ingress module
       ingress:
         baseDomain: sighup.example.tld
+        nginx:
+          type: none
         haproxy:
           type: single
           tls:


### PR DESCRIPTION
As per title